### PR TITLE
Improve setlist tracker display

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -5,20 +5,48 @@
 <title>School of Rock Setlist Tracker</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
-<style>
- body { font-family: Arial, sans-serif; padding:20px; background:#f4f4f4; }
- h1 { text-align:center; }
- #controls { margin-bottom:15px; }
- #setlist { list-style:none; padding:0; }
- #setlist li { padding:8px; background:#fff; margin-bottom:4px; border-radius:4px; display:flex; align-items:center; justify-content:space-between; }
- #setlist li.playing { background:#cfe2ff; }
- #setlist li.should { background:#d1e7dd; }
+ <style>
+  body { font-family: Arial, sans-serif; padding:20px; background:#f4f4f4; }
+  h1 { text-align:center; }
+  #controls { margin-bottom:15px; }
+  #timerDisplay {
+      font-size:2em;
+      font-weight:bold;
+      margin-left:10px;
+  }
+  #currentSongDisplay {
+      font-size:1.5em;
+      font-weight:bold;
+      text-align:center;
+      margin:10px 0;
+  }
+  #progressContainer {
+      height:20px;
+      background:#ddd;
+      border-radius:10px;
+      overflow:hidden;
+      margin:10px 0;
+  }
+  #progressBar {
+      height:100%;
+      width:0%;
+      background:#4caf50;
+  }
+  #aheadBehind {
+      text-align:center;
+      font-size:1.2em;
+      margin-top:5px;
+  }
+  #setlist { list-style:none; padding:0; }
+  #setlist li { padding:8px; background:#fff; margin-bottom:4px; border-radius:4px; display:flex; align-items:center; justify-content:space-between; }
+  #setlist li.playing { background:#cfe2ff; }
+  #setlist li.should { background:#d1e7dd; }
 .song-info { flex:1; }
 .drop-label { margin-left:10px; font-size:0.9em; }
 .time { width:60px; text-align:right; margin-left:10px; }
  .runtime { width:60px; text-align:right; margin-left:10px; }
 .remove { margin-left:10px; }
-</style>
+ </style>
 </head>
 <body>
 <h1>Setlist Tracker</h1>
@@ -32,6 +60,9 @@
     <span id="timerDisplay">00:00</span>
     <span id="timeRemaining"></span>
 </div>
+<div id="currentSongDisplay"></div>
+<div id="progressContainer"><div id="progressBar"></div></div>
+<div id="aheadBehind"></div>
 <ul id="setlist"></ul>
 <script>
 let songs = [];
@@ -139,6 +170,30 @@ function updateDisplay(){
     document.getElementById('timerDisplay').textContent=formatTime(elapsed);
     const maxSec=parseInt(document.getElementById('maxTime').value)*60;
     document.getElementById('timeRemaining').textContent=' | remaining: '+formatTime(maxSec-elapsed);
+    const progress=document.getElementById('progressBar');
+    if(progress){
+        progress.style.width=Math.min(100,elapsed/maxSec*100)+"%";
+    }
+    const curSong=songs[currentIndex];
+    const songEl=document.getElementById('currentSongDisplay');
+    if(songEl){
+        songEl.textContent=curSong?`${currentIndex+1}. ${curSong.title} - ${curSong.artist}`:'';
+    }
+    const diffEl=document.getElementById('aheadBehind');
+    if(diffEl){
+        if(curSong){
+            const diff=elapsed-curSong.start;
+            if(Math.abs(diff)<1){
+                diffEl.textContent='On time';
+            }else if(diff>0){
+                diffEl.textContent=`Behind ${formatTime(diff)}`;
+            }else{
+                diffEl.textContent=`Ahead ${formatTime(-diff)}`;
+            }
+        }else{
+            diffEl.textContent='';
+        }
+    }
     let shouldIndex=null;
     for(let i=0;i<songs.length;i++){
         if(elapsed < songs[i].start + songs[i].duration){


### PR DESCRIPTION
## Summary
- make timer, current song, and progress bar more prominent
- show how far ahead or behind the current song is from the schedule

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f66899664832eb6106e2ca8e39829