### PR TITLE
Set default transition time to 60s

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -53,7 +53,7 @@
 <div id="controls">
     <input type="file" id="csvFile" accept=".csv">
     <label>Max Time (min): <input type="number" id="maxTime" value="60" min="1"></label>
-    <label>Transition (sec): <input type="number" id="transitionTime" value="0" min="0"></label>
+    <label>Transition (sec): <input type="number" id="transitionTime" value="60" min="0"></label>
     <button id="startBtn">Start</button>
     <button id="prevBtn">&lt;</button>
     <button id="nextBtn">&gt;</button>


### PR DESCRIPTION
## Summary
- set the default transition time for the setlist tracker to 60 seconds

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683f691dff98832e843fdf6c4494e14b