### PR TITLE
Add .DS_Store and .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _site
 vendor
 .swp
 .swo
+.DS_Store
+.idea/


### PR DESCRIPTION
## Summary
- extend `.gitignore` to ignore macOS `.DS_Store` files and `.idea` project directory

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f71bc9108832e8eba6086ff3eb10a