### PR TITLE
Add real-time setlist metrics

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -38,6 +38,11 @@
       font-size:1.5em;
       margin:10px 0;
   }
+  #clockTime,#projectedEnd,#droppedInfo,#transitionInfo{
+      text-align:center;
+      margin:4px 0;
+      font-size:1em;
+  }
   #setlist { list-style:none; padding:0; }
   #setlist li { padding:8px; background:#fff; margin-bottom:4px; border-radius:4px; display:flex; align-items:center; justify-content:space-between; }
   #setlist li.playing { background:#cfe2ff; }
@@ -76,6 +81,10 @@
 <span id="timerDisplay">00:00</span>
 <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
 <div id="aheadBehind"></div>
+<div id="clockTime"></div>
+<div id="projectedEnd"></div>
+<div id="droppedInfo"></div>
+<div id="transitionInfo"></div>
 <ul id="setlist"></ul>
 <div id="fileControls">
     <input type="file" id="csvFile" accept=".csv">
@@ -90,6 +99,8 @@ let currentIndex = 0;
 let speedFactor = 1;
 let songStart = 0; // actual start time (sec) of the current song
 const startDiff = []; // difference of actual start vs scheduled start per song
+const actualStart = [];
+const transitionDurations = [];
 
 // Check query string for a debugging speed multiplier, e.g. ?debugspeed=5
 // This is intentionally hidden so regular users don't accidentally change it.
@@ -117,6 +128,10 @@ function formatTime(sec){
     const m = Math.floor(sec/60);
     const s = sec%60;
     return `${m}:${s.toString().padStart(2,'0')}`;
+}
+
+function formatClock(date){
+    return date.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
 }
 
 document.getElementById('csvFile').addEventListener('change', e=>{
@@ -256,6 +271,24 @@ function computeDroppedSongs(elapsed){
     }
 }
 
+function remainingDuration(withDrops, elapsed){
+    const transition=parseInt(document.getElementById('transitionTime').value)||0;
+    const remainIdx=[];
+    for(let i=currentIndex;i<songs.length;i++){
+        if(withDrops && songs[i].dropped) continue;
+        remainIdx.push(i);
+    }
+    let t=0;
+    const progress=Math.max(0, elapsed - songStart);
+    remainIdx.forEach((idx,j)=>{
+        let dur=songs[idx].duration;
+        if(idx===currentIndex) dur=Math.max(0,dur-progress);
+        t+=dur;
+        if(j<remainIdx.length-1) t+=transition;
+    });
+    return t;
+}
+
 function updateDisplay(){
     const elapsed=startTime ? Math.floor((Date.now()-startTime)/1000*speedFactor) : 0;
     computeDroppedSongs(elapsed);
@@ -293,6 +326,28 @@ function updateDisplay(){
             diffEl.textContent='';
         }
     }
+    const clockEl=document.getElementById('clockTime');
+    if(clockEl){
+        clockEl.textContent='Current: '+formatClock(new Date());
+    }
+    const endEl=document.getElementById('projectedEnd');
+    if(endEl){
+        const rd=remainingDuration(true, elapsed);
+        const ra=remainingDuration(false, elapsed);
+        const endDrop=new Date(Date.now()+rd*1000/speedFactor);
+        const endAll=new Date(Date.now()+ra*1000/speedFactor);
+        endEl.textContent=`End w/drops: ${formatClock(endDrop)} | w/out: ${formatClock(endAll)}`;
+    }
+    const dropEl=document.getElementById('droppedInfo');
+    if(dropEl){
+        const count=songs.filter(s=>s.dropped).length;
+        dropEl.textContent=`Dropped songs: ${count}`;
+    }
+    const transEl=document.getElementById('transitionInfo');
+    if(transEl){
+        const avg=transitionDurations.length?transitionDurations.reduce((a,b)=>a+b,0)/transitionDurations.length:0;
+        transEl.textContent=`Avg transition: ${formatTime(avg)}`;
+    }
     let shouldIndex=null;
     for(let i=0;i<songs.length;i++){
         if(elapsed < songs[i].start + songs[i].duration){
@@ -317,6 +372,7 @@ function startTimer(){
     startTime=Date.now();
     songStart=0;
     startDiff[0]=0;
+    actualStart[0]=0;
     timer=setInterval(updateDisplay,1000/speedFactor);
 }
 
@@ -326,13 +382,21 @@ document.getElementById('prevBtn').addEventListener('click', ()=>{
     const elapsed=startTime?Math.floor((Date.now()-startTime)/1000):0;
     songStart=elapsed;
     startDiff[currentIndex]=elapsed - songs[currentIndex].start;
+    actualStart[currentIndex]=elapsed;
     updateDisplay();
 });
 document.getElementById('nextBtn').addEventListener('click', ()=>{
-    currentIndex=Math.min(songs.length-1,currentIndex+1);
     const elapsed=startTime?Math.floor((Date.now()-startTime)/1000):0;
-    songStart=elapsed;
-    startDiff[currentIndex]=elapsed - songs[currentIndex].start;
+    if(currentIndex<songs.length-1){
+        if(actualStart[currentIndex]!==undefined){
+            const trans=elapsed - actualStart[currentIndex] - songs[currentIndex].duration;
+            if(trans>=0) transitionDurations[currentIndex]=trans;
+        }
+        currentIndex=Math.min(songs.length-1,currentIndex+1);
+        songStart=elapsed;
+        startDiff[currentIndex]=elapsed - songs[currentIndex].start;
+        actualStart[currentIndex]=elapsed;
+    }
     updateDisplay();
 });
 document.getElementById('transitionTime').addEventListener('change', renderSetlist);


### PR DESCRIPTION
## Summary
- add info rows for current time, projected end, dropped count and average transition
- track actual song start times and transitions
- compute projected finish times with and without dropped songs

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f78064dd4832eb240ad1e4a1b3505