### PR TITLE
Add pause/resume and stop summary to setlist tracker

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -68,6 +68,8 @@
 <h1>Setlist Tracker</h1>
 <div id="navControls">
     <button id="startBtn">Start</button>
+    <button id="pauseBtn">Pause</button>
+    <button id="stopBtn">Stop</button>
     <button id="prevBtn">&lt;</button>
     <button id="nextBtn">&gt;</button>
 </div>
@@ -90,6 +92,9 @@ let currentIndex = 0;
 let speedFactor = 1;
 let songStart = 0; // actual start time (sec) of the current song
 const startDiff = []; // difference of actual start vs scheduled start per song
+let isPaused = false;
+let pauseStart = 0;
+let totalPause = 0; // accumulated pause time in ms
 
 // Check query string for a debugging speed multiplier, e.g. ?debugspeed=5
 // This is intentionally hidden so regular users don't accidentally change it.
@@ -119,6 +124,13 @@ function formatTime(sec){
     return `${m}:${s.toString().padStart(2,'0')}`;
 }
 
+function getElapsedMs(){
+    if(!startTime) return 0;
+    let paused = totalPause;
+    if(isPaused) paused += Date.now()-pauseStart;
+    return Date.now() - startTime - paused;
+}
+
 document.getElementById('csvFile').addEventListener('change', e=>{
     const file = e.target.files[0];
     if(!file) return;
@@ -136,6 +148,8 @@ function loadSongs(data){
         timer=null;
     }
     startTime=null;
+    isPaused=false;
+    totalPause=0;
     currentIndex=0;
     data.forEach(row=>{
         const normalized = {};
@@ -257,7 +271,7 @@ function computeDroppedSongs(elapsed){
 }
 
 function updateDisplay(){
-    const elapsed=startTime ? Math.floor((Date.now()-startTime)/1000*speedFactor) : 0;
+    const elapsed=startTime ? Math.floor(getElapsedMs()/1000*speedFactor) : 0;
     computeDroppedSongs(elapsed);
     document.getElementById('timerDisplay').textContent=formatTime(elapsed);
     const maxSec=parseInt(document.getElementById('maxTime').value)*60;
@@ -315,22 +329,66 @@ function updateDisplay(){
 function startTimer(){
     if(timer) return;
     startTime=Date.now();
+    isPaused=false;
+    totalPause=0;
     songStart=0;
     startDiff[0]=0;
     timer=setInterval(updateDisplay,1000/speedFactor);
 }
 
+function togglePause(){
+    if(!startTime) return;
+    const btn=document.getElementById('pauseBtn');
+    if(isPaused){
+        totalPause+=Date.now()-pauseStart;
+        isPaused=false;
+        timer=setInterval(updateDisplay,1000/speedFactor);
+        if(btn) btn.textContent='Pause';
+    }else{
+        if(timer){
+            clearInterval(timer);
+            timer=null;
+        }
+        isPaused=true;
+        pauseStart=Date.now();
+        if(btn) btn.textContent='Resume';
+    }
+    updateDisplay();
+}
+
+function stopTimer(){
+    if(!startTime) return;
+    if(timer){
+        clearInterval(timer);
+        timer=null;
+    }
+    if(isPaused){
+        totalPause+=Date.now()-pauseStart;
+        isPaused=false;
+        const btn=document.getElementById('pauseBtn');
+        if(btn) btn.textContent='Pause';
+    }
+    const elapsedSec=Math.floor(getElapsedMs()/1000*speedFactor);
+    const pauseSec=Math.floor(totalPause/1000*speedFactor);
+    let playedDur=0;
+    for(let i=0;i<=currentIndex && i<songs.length;i++) playedDur+=songs[i].duration;
+    const transitionSec=Math.max(0,elapsedSec-playedDur);
+    alert(`Songs played: ${currentIndex+1}\nEstimated transition time: ${formatTime(transitionSec)}\nTime paused: ${formatTime(pauseSec)}`);
+}
+
 document.getElementById('startBtn').addEventListener('click', startTimer);
+document.getElementById('pauseBtn').addEventListener('click', togglePause);
+document.getElementById('stopBtn').addEventListener('click', stopTimer);
 document.getElementById('prevBtn').addEventListener('click', ()=>{
     currentIndex=Math.max(0,currentIndex-1);
-    const elapsed=startTime?Math.floor((Date.now()-startTime)/1000):0;
+    const elapsed=startTime?Math.floor(getElapsedMs()/1000):0;
     songStart=elapsed;
     startDiff[currentIndex]=elapsed - songs[currentIndex].start;
     updateDisplay();
 });
 document.getElementById('nextBtn').addEventListener('click', ()=>{
     currentIndex=Math.min(songs.length-1,currentIndex+1);
-    const elapsed=startTime?Math.floor((Date.now()-startTime)/1000):0;
+    const elapsed=startTime?Math.floor(getElapsedMs()/1000):0;
     songStart=elapsed;
     startDiff[currentIndex]=elapsed - songs[currentIndex].start;
     updateDisplay();


### PR DESCRIPTION
## Summary
- add Pause and Stop buttons to the setlist tracker UI
- support pausing/resuming timer
- show summary when stopping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7889076c832e8afc501d42171bcb