### PR TITLE
Fix stop reset for setlist tracker

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -498,6 +498,13 @@ function stopTimer(){
     for(let i=0;i<=currentIndex && i<songs.length;i++) playedDur+=songs[i].duration;
     const transitionSec=Math.max(0,elapsedSec-playedDur);
     alert(`Songs played: ${currentIndex+1}\nEstimated transition time: ${formatTime(transitionSec)}\nTime paused: ${formatTime(pauseSec)}`);
+    currentIndex = 0;
+    songStart = 0;
+    startDiff.length = 0;
+    actualStart.length = 0;
+    startTime = null;
+    totalPause = 0;
+    updateDisplay();
 }
 
 document.getElementById('startBtn').addEventListener('click', startTimer);


### PR DESCRIPTION
## Summary
- reset the current song to the first item when Stop is clicked

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fad486008832e8175960f50e5437b