### PR TITLE
Improve ahead timer calculations

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -399,22 +399,48 @@ function updateDisplay(){
     }
     const diffEl=document.getElementById('aheadBehind');
     if(diffEl){
+        diffEl.style.color='';
         if(curSong){
-            diffEl.style.color='';
-
-            const progress=Math.max(0,elapsed-songStart);
-            const delta=startDiff[currentIndex] ?? (elapsed-curSong.start);
-            const diff=delta*(curSong.duration?Math.min(progress/curSong.duration,1):1);
-
-            if(Math.abs(diff)<1){
-                diffEl.textContent='On time';
-            }else if(diff>0){
-                diffEl.textContent=`Behind ${formatTime(diff)}`;
-                diffEl.style.color='goldenrod';
-            }else{
-                diffEl.textContent=`Ahead ${formatTime(-diff)}`;
-                diffEl.style.color='blue';
+            // Determine how far ahead or behind we are compared to the schedule
+            let shouldIdx=null;
+            for(let i=0;i<songs.length;i++){
+                if(elapsed < songs[i].start + songs[i].duration){ shouldIdx=i; break; }
             }
+            if(shouldIdx===null) shouldIdx=songs.length-1;
+
+            const schedDiff=songs[shouldIdx].start - songs[currentIndex].start;
+
+            const maxSec=parseInt(document.getElementById('maxTime').value)*60;
+            const remWith=remainingDuration(true, elapsed);
+            const remAll=remainingDuration(false, elapsed);
+            const endDiff=maxSec - (elapsed + remWith);
+            const dropped=remAll - remWith;
+
+            let text='On time';
+            if(!autoDrop){
+                if(Math.abs(schedDiff)>=1){
+                    if(schedDiff>0){
+                        text=`Behind ${formatTime(schedDiff)}`;
+                        diffEl.style.color='red';
+                    }else{
+                        text=`Ahead ${formatTime(-schedDiff)}`;
+                        diffEl.style.color='blue';
+                    }
+                }
+            }else{
+                if(Math.abs(endDiff)>=1){
+                    if(endDiff<0){
+                        text=`Behind ${formatTime(-endDiff)}`;
+                        diffEl.style.color='red';
+                    }else{
+                        text=`Ahead ${formatTime(endDiff)}`;
+                        diffEl.style.color='blue';
+                    }
+                }
+                if(dropped>0) text+=` (Dropped ${formatTime(dropped)})`;
+            }
+
+            diffEl.textContent=text;
         }else{
             diffEl.textContent='';
         }


### PR DESCRIPTION
## Summary
- refine the ahead/behind timer logic in **setlist_tracker.html**
- show schedule difference when Auto Drop is off
- show end-time difference and dropped time when Auto Drop is on
- change behind color to red

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing)*

------
https://chatgpt.com/codex/tasks/task_e_683faff052c4832e87c8f1b3f153176c