### PR TITLE
Fix drop logic update on max time change

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -570,6 +570,11 @@ document.getElementById('nextBtn').addEventListener('click', () => {
     updateDisplay();
 });
 document.getElementById('transitionTime').addEventListener('change', renderSetlist);
+document.getElementById('maxTime').addEventListener('change', () => {
+    const elapsed = startTime ? Math.floor(getElapsedMs()/1000*speedFactor) : 0;
+    if(autoDrop) computeDroppedSongs(elapsed);
+    updateDisplay();
+});
 document.getElementById('dropBtn').addEventListener('click', ()=>{
     const elapsed=startTime ? Math.floor(getElapsedMs()/1000*speedFactor) : 0;
     computeDroppedSongs(elapsed);


### PR DESCRIPTION
## Summary
- recompute dropped songs when max time input changes

## Testing
- `bundle install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_683fb80683a8832e852a22f2b86658eb