### PR TITLE
Add metronome to setlist tracker

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -86,6 +86,7 @@
 .protect-label { margin-left:10px; font-size:0.9em; }
 .time { width:60px; text-align:right; margin-left:10px; }
  .runtime { width:60px; text-align:right; margin-left:10px; }
+.bpm { width:70px; text-align:right; margin-left:10px; }
 .remove { margin-left:10px; }
   #navControls{
       text-align:center;
@@ -106,6 +107,22 @@
   }
   .highlight{
       background:#ff9800 !important;
+  }
+  #metronomeControls{
+      text-align:center;
+      margin:10px 0;
+  }
+  #metronomeBeat{
+      width:20px;
+      height:20px;
+      margin:10px auto;
+      border-radius:50%;
+      background:#4caf50;
+      opacity:0.2;
+      transition:opacity 0.1s;
+  }
+  #metronomeBeat.active{
+      opacity:1;
   }
   #fileControls{
       margin-top:20px;
@@ -148,9 +165,14 @@
 </div>
 <div id="currentSongDisplay"></div>
 <div id="nextSongDisplay"></div>
-<div id="progressContainer"><div id="progressBar"></div></div>
-<span id="timerDisplay">00:00</span>
-<div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
+  <div id="progressContainer"><div id="progressBar"></div></div>
+  <span id="timerDisplay">00:00</span>
+  <div id="metronomeControls">
+      <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>
+      <label><input type="checkbox" id="metronomeToggle"> Metronome</label>
+      <div id="metronomeBeat"></div>
+  </div>
+  <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
 <div id="aheadBehind"></div>
 <div id="clockTime"></div>
 <div id="projectedEnd"></div>
@@ -183,6 +205,9 @@ let totalPause = 0; // accumulated pause time in ms
 const actualStart = [];
 const transitionDurations = [];
 let autoDrop = true;
+let currentBpm = 120;
+let metronomeTimer = null;
+let lastSongAppliedBpm = -1;
 
 // Check query string for a debugging speed multiplier, e.g. ?debugspeed=5
 // This is intentionally hidden so regular users don't accidentally change it.
@@ -224,6 +249,41 @@ function formatClock(date){
     return date.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
 }
 
+function startMetronome(){
+    if(metronomeTimer) clearInterval(metronomeTimer);
+    const beatEl=document.getElementById('metronomeBeat');
+    if(!beatEl) return;
+    const interval=60000/Math.max(1,currentBpm);
+    metronomeTimer=setInterval(()=>{
+        beatEl.classList.add('active');
+        setTimeout(()=>beatEl.classList.remove('active'),100);
+    },interval);
+}
+
+function stopMetronome(){
+    if(metronomeTimer) clearInterval(metronomeTimer);
+    metronomeTimer=null;
+    const beatEl=document.getElementById('metronomeBeat');
+    if(beatEl) beatEl.classList.remove('active');
+}
+
+function setMetronomeBpm(bpm){
+    if(!bpm || isNaN(bpm)) return;
+    currentBpm=parseInt(bpm);
+    const inp=document.getElementById('bpmInput');
+    if(inp) inp.value=currentBpm;
+    const toggle=document.getElementById('metronomeToggle');
+    if(toggle && toggle.checked) startMetronome();
+}
+
+function applySongBpm(){
+    const song=songs[currentIndex];
+    if(song && song.bpm && currentIndex!==lastSongAppliedBpm){
+        setMetronomeBpm(song.bpm);
+        lastSongAppliedBpm=currentIndex;
+    }
+}
+
 document.getElementById('csvFile').addEventListener('change', e=>{
     const file = e.target.files[0];
     if(!file) return;
@@ -252,17 +312,24 @@ function loadSongs(data){
         const title = normalized['song'] || normalized['title'];
         const artist = normalized['artist'];
         const durField = normalized['duration'] || normalized['time'];
+        const bpmField = normalized['bpm'] || normalized['tempo'];
         if(!title && !artist) return; // ignore note rows
         songs.push({
             title: title || '',
             artist: artist || '',
             duration: parseDuration(durField),
+            bpm: bpmField ? parseInt(bpmField) : null,
             dropFirst:false,
             dropNum:1,
             start:0,
             protect:false
         });
     });
+    lastSongAppliedBpm=-1;
+    if(songs.length && songs[0].bpm){
+        setMetronomeBpm(songs[0].bpm);
+        lastSongAppliedBpm=0;
+    }
     renderSetlist();
     updateDisplay();
 }
@@ -280,6 +347,7 @@ function renderSetlist(){
         li.innerHTML=`<span class="song-info">${i+1}. ${song.title} - ${song.artist}</span>
             <span class="runtime">${formatTime(song.start)}</span>
             <span class="time">${formatTime(song.duration)}</span>
+            <span class="bpm">${song.bpm?song.bpm+' BPM':''}</span>
             <label class="drop-label"><input type="checkbox" class="drop" data-idx="${i}" ${song.dropFirst?'checked':''}> drop <input type="number" class="drop-num" data-idx="${i}" min="1" value="${song.dropNum}" style="width:3em" ${song.dropFirst?'':'disabled'}></label>
             <label class="protect-label"><input type="checkbox" class="protect" data-idx="${i}" ${song.protect?'checked':''}> keep</label>
             <button class="remove" data-idx="${i}">Remove</button>`;
@@ -399,6 +467,7 @@ function updateDisplay(){
         progress.style.width=Math.min(100,elapsed/maxSec*100)+"%";
     }
     const curSong=songs[currentIndex];
+    applySongBpm();
     const songEl=document.getElementById('currentSongDisplay');
     if(songEl){
         songEl.textContent=curSong?`${currentIndex+1}. ${curSong.title} - ${curSong.artist}`:'';
@@ -520,6 +589,8 @@ function startTimer(){
     startDiff[0]=0;
     actualStart[0]=0;
     timer=setInterval(updateDisplay,1000/speedFactor);
+    const toggle=document.getElementById('metronomeToggle');
+    if(toggle && toggle.checked) startMetronome();
     updateDisplay();
 }
 
@@ -555,6 +626,7 @@ function stopTimer(){
         const btn=document.getElementById('pauseBtn');
         if(btn) btn.textContent='Pause';
     }
+    stopMetronome();
     const elapsedSec=Math.floor(getElapsedMs()/1000*speedFactor);
     const pauseSec=Math.floor(totalPause/1000*speedFactor);
     let playedDur=0;
@@ -612,6 +684,16 @@ document.getElementById('autoDrop').addEventListener('change', e=>{
     if(autoDrop) computeDroppedSongs(elapsed);
     updateDropBtnHighlight();
     updateDisplay();
+});
+document.getElementById('metronomeToggle').addEventListener('change', e=>{
+    if(e.target.checked) startMetronome();
+    else stopMetronome();
+});
+document.getElementById('bpmInput').addEventListener('change', e=>{
+    const val=parseInt(e.target.value);
+    if(!isNaN(val) && val>0){
+        setMetronomeBpm(val);
+    }
 });
 updateDropBtnHighlight();
 </script>


### PR DESCRIPTION
## Summary
- add CSS and DOM for a visual metronome
- import BPM from CSV and render BPM per song
- start/stop metronome and match BPM when switching songs
- add controls for metronome BPM and toggle

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fb984cba8832eabc5e67857ac5d68