### PR TITLE
Adjust metronome UI

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -113,11 +113,12 @@
   }
   #metronomeControls{
       text-align:center;
-      margin:10px 0;
+      margin-top:auto;
+      margin-bottom:10px;
   }
   #metronomeBeat{
-      width:20px;
-      height:20px;
+      width:40px;
+      height:40px;
       margin:10px auto;
       border-radius:50%;
       background:#4caf50;
@@ -155,6 +156,10 @@
       overflow-y:auto;
       max-height:60vh;
   }
+  #infoColumn{
+      display:flex;
+      flex-direction:column;
+  }
   @media (min-width:800px){
       #contentWrapper{ flex-direction:row; align-items:flex-start; }
       #infoColumn{ flex:1; padding-right:20px; }
@@ -187,8 +192,8 @@
   <div id="progressContainer"><div id="progressBar"></div></div>
   <span id="timerDisplay">00:00</span>
   <div id="metronomeControls">
+      <label><input type="checkbox" id="metronomeToggle"></label>
       <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>
-      <label><input type="checkbox" id="metronomeToggle"> Metronome</label>
       <div id="metronomeBeat"></div>
   </div>
   <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>


### PR DESCRIPTION
## Summary
- anchor metronome controls to bottom of info panel
- enlarge metronome flasher
- reorder checkbox and remove label text

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840663037a4832e8e96a4fff00b15f3