### PR TITLE
Set Auto Drop unchecked by default

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -210,7 +210,7 @@
         <label>Max Time (min): <input type="number" id="maxTime" value="60" min="1"></label>
         <label>End By: <input type="time" id="endBy"></label>
         <label>Transition (sec): <input type="number" id="transitionTime" value="60" min="0"></label>
-        <label><input type="checkbox" id="autoDrop" checked> Auto Drop</label>
+        <label><input type="checkbox" id="autoDrop"> Auto Drop</label>
     </div>
 </div>
 </div>
@@ -227,7 +227,7 @@ let pauseStart = 0;
 let totalPause = 0; // accumulated pause time in ms
 const actualStart = [];
 const transitionDurations = [];
-let autoDrop = true;
+let autoDrop = false;
 let currentBpm = 120;
 let metronomeTimer = null;
 let lastSongAppliedBpm = -1;


### PR DESCRIPTION
## Summary
- remove `checked` attribute from Auto Drop checkbox
- initialize `autoDrop` state to `false` so Auto Drop starts disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840664202a8832e93233f2684bbfd11