### PR TITLE
Update setlist tracker time display

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -72,6 +72,10 @@
       margin:4px 0;
       font-size:1em;
   }
+  #clockTime,#projectedEnd{
+      display:inline-block;
+      margin:4px 8px;
+  }
   #setlist { list-style:none; padding:0; }
   #setlist li {
       padding:12px;
@@ -471,7 +475,13 @@ function updateDisplay(){
     updateDropBtn(elapsed);
     document.getElementById('timerDisplay').textContent=formatTime(elapsed);
     const maxSec=parseInt(document.getElementById('maxTime').value)*60;
-    document.getElementById('timeRemaining').textContent='Remaining: '+formatTime(maxSec-elapsed);
+    const setRemain=remainingDuration(true, elapsed);
+    const gigRemain=Math.max(0, maxSec-elapsed);
+    const remEl=document.getElementById('timeRemaining');
+    if(remEl){
+        remEl.textContent=`${formatTime(setRemain)} of ${formatTime(gigRemain)}`;
+        remEl.style.color=setRemain>gigRemain?'red':'blue';
+    }
     const progress=document.getElementById('progressBar');
     if(progress){
         progress.style.width=Math.min(100,elapsed/maxSec*100)+"%";
@@ -541,15 +551,13 @@ function updateDisplay(){
     }
     const clockEl=document.getElementById('clockTime');
     if(clockEl){
-        clockEl.textContent='Current: '+formatClock(new Date());
+        clockEl.textContent=`Now: ${formatClock(new Date())}`;
     }
     const endEl=document.getElementById('projectedEnd');
     if(endEl){
         const rd=remainingDuration(true, elapsed);
-        const ra=remainingDuration(false, elapsed);
-        const endDrop=new Date(Date.now()+rd*1000/speedFactor);
-        const endAll=new Date(Date.now()+ra*1000/speedFactor);
-        endEl.textContent=`End w/drops: ${formatClock(endDrop)} | w/out: ${formatClock(endAll)}`;
+        const endTime=new Date(Date.now()+rd*1000/speedFactor);
+        endEl.textContent=`Setlist End: ${formatClock(endTime)}`;
     }
     const dropEl=document.getElementById('droppedInfo');
     if(dropEl){


### PR DESCRIPTION
## Summary
- clarify the remaining time display so it shows setlist time vs gig time
- color-code the remaining time when over or under
- simplify projected end display and show current time alongside it

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a3cd114832ea70768b879de02e1