### PR TITLE
Fix guitar transitions in setlist optimizer

### DIFF
--- a/sor/setlist_optimizer.html
+++ b/sor/setlist_optimizer.html
@@ -675,6 +675,7 @@
                 // Process instrument assignments
                 const instrumentMapping = {
                     'Vox': ['Vox', 'Vocals', 'Singer', 'Voice'],
+                    'Guitar': ['Guitar'],
                     'Guitar 1': ['Guitar 1', 'Gtr 1', 'Lead Guitar'],
                     'Guitar 2': ['Guitar 2', 'Gtr 2', 'Rhythm Guitar'],
                     'Guitar 3': ['Guitar 3', 'Gtr 3'],
@@ -870,6 +871,7 @@
             function getPlayers(song, instrument) {
                 if (instrument === 'Guitar') {
                     return []
+                        .concat(song.instruments['Guitar'] || [])
                         .concat(song.instruments['Guitar 1'] || [])
                         .concat(song.instruments['Guitar 2'] || [])
                         .concat(song.instruments['Guitar 3'] || []);


### PR DESCRIPTION
## Summary
- support generic `Guitar` column when parsing CSV
- include `Guitar` column in transition cost calculations

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406af82148832e98c5d38d253b06c4