### PR TITLE
Fix manual drop control and real-time projections

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -350,7 +350,9 @@ function loadSongs(data){
             notes: notesField || '',
             keepOrder:1,
             start:0,
-            protect:false
+            protect:false,
+            dropped:false,
+            manualDrop:false
         });
     });
     lastSongAppliedBpm=-1;
@@ -372,7 +374,7 @@ function renderSetlist(){
         cumulative+=song.duration+transition;
         const li=document.createElement('li');
         li.dataset.index=i;
-        li.innerHTML=`<div class="song-info"><label class="protect-label"><input type="checkbox" class="protect" data-idx="${i}" ${song.protect?'checked':''}></label> ${i+1}. ${song.title} - ${song.artist}</div>
+        li.innerHTML=`<div class="song-info"><label class="protect-label"><input type="checkbox" class="drop-toggle" data-idx="${i}" ${song.dropped?'':'checked'}></label> ${i+1}. ${song.title} - ${song.artist}</div>
             <div class="song-controls">
                 <span class="runtime">${formatTime(song.start)}</span>
                 <span class="time">${formatTime(song.duration)}</span>
@@ -381,10 +383,17 @@ function renderSetlist(){
             </div>`;
         list.appendChild(li);
     });
-    document.querySelectorAll('.protect').forEach(cb=>{
+    document.querySelectorAll('.drop-toggle').forEach(cb=>{
         cb.addEventListener('change',e=>{
             const idx=parseInt(e.target.dataset.idx);
-            songs[idx].protect=e.target.checked;
+            const checked=e.target.checked;
+            songs[idx].dropped=!checked;
+            songs[idx].manualDrop=!checked;
+            if(autoDrop){
+                const elapsed=startTime?Math.floor(getElapsedMs()/1000*speedFactor):0;
+                computeDroppedSongs(elapsed);
+            }
+            updateDisplay();
         });
     });
     document.querySelectorAll('.keep-order').forEach(inp=>{
@@ -403,10 +412,12 @@ function computeDroppedSongs(elapsed){
     const remaining=maxSec-elapsed;
     const transition=parseInt(document.getElementById('transitionTime').value)||0;
 
-    songs.forEach(s=>s.dropped=false);
+    songs.forEach(s=>{ if(!s.manualDrop) s.dropped=false; });
 
     const pending=[];
-    for(let i=currentIndex;i<songs.length;i++) pending.push(i);
+    for(let i=currentIndex;i<songs.length;i++){
+        if(!songs[i].manualDrop) pending.push(i);
+    }
     const droppable=pending.filter(i=>!songs[i].protect);
 
     const totalDur=idxs=>{
@@ -432,6 +443,7 @@ function computeDroppedSongs(elapsed){
         if(totalDur(keep)<=remaining) break;
         keep=keep.filter(k=>k!==idx);
         songs[idx].dropped=true;
+        songs[idx].manualDrop=false;
     }
 }
 
@@ -467,6 +479,7 @@ function remainingDuration(withDrops, elapsed){
 
 function updateDisplay(){
     const elapsed=startTime ? Math.floor(getElapsedMs()/1000*speedFactor) : 0;
+    const realElapsed=startTime ? Math.floor(getElapsedMs()/1000) : 0;
     if(autoDrop) computeDroppedSongs(elapsed);
     updateDropBtn(elapsed);
     document.getElementById('timerDisplay').textContent=formatTime(elapsed);
@@ -545,10 +558,10 @@ function updateDisplay(){
     }
     const endEl=document.getElementById('projectedEnd');
     if(endEl){
-        const rd=remainingDuration(true, elapsed);
-        const ra=remainingDuration(false, elapsed);
-        const endDrop=new Date(Date.now()+rd*1000/speedFactor);
-        const endAll=new Date(Date.now()+ra*1000/speedFactor);
+        const rd=remainingDuration(true, realElapsed);
+        const ra=remainingDuration(false, realElapsed);
+        const endDrop=new Date(Date.now()+rd*1000);
+        const endAll=new Date(Date.now()+ra*1000);
         endEl.textContent=`End w/drops: ${formatClock(endDrop)} | w/out: ${formatClock(endAll)}`;
     }
     const dropEl=document.getElementById('droppedInfo');


### PR DESCRIPTION
## Summary
- connect per-song checkbox to dropped state so remaining time updates
- preserve manual drops when auto-dropping
- compute projected end times in real time instead of using debug speed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406abc4600832ebea117d2eedb6486