### PR TITLE
Move metronome to bottom of tracker page

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -194,17 +194,17 @@
 <div id="nextSongDisplay"></div>
   <div id="progressContainer"><div id="progressBar"></div></div>
   <span id="timerDisplay">00:00</span>
-  <div id="metronomeControls">
-      <label><input type="checkbox" id="metronomeToggle"></label>
-      <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>
-      <div id="metronomeBeat"></div>
-  </div>
   <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
 <div id="aheadBehind"></div>
 <div id="clockTime"></div>
 <div id="projectedEnd"></div>
 <div id="droppedInfo"></div>
 <div id="transitionInfo"></div>
+  <div id="metronomeControls">
+      <label><input type="checkbox" id="metronomeToggle"></label>
+      <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>
+      <div id="metronomeBeat"></div>
+  </div>
 </div> <!-- infoColumn -->
 <div id="songsColumn">
 <ul id="setlist"></ul>


### PR DESCRIPTION
## Summary
- move the metronome controls to the end of the info column so it's below the Avg transition info

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406d89f0cc832e8af7a8051bb5b7fc