### PR TITLE
Push metronome control to bottom

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -163,6 +163,9 @@
       display:flex;
       flex-direction:column;
   }
+  #infoSpacer{
+      flex-grow:1;
+  }
   @media (min-width:800px){
       #contentWrapper{ flex-direction:row; align-items:flex-start; }
       #infoColumn{ flex:1; padding-right:20px; }
@@ -200,6 +203,7 @@
 <div id="projectedEnd"></div>
 <div id="droppedInfo"></div>
 <div id="transitionInfo"></div>
+<div id="infoSpacer"></div>
   <div id="metronomeControls">
       <label><input type="checkbox" id="metronomeToggle"></label>
       <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>


### PR DESCRIPTION
## Summary
- push metronome to bottom of the left pane with a flex spacer

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684074d52914832e8c6cc61416e52556