### PR TITLE
Fix drop order tie handling

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -441,6 +441,7 @@ function computeDroppedSongs(elapsed){
     if(totalDur(keep)<=remaining) return;
 
     const closerIdx=songs.length-1;
+    // Sort drop candidates so we always drop from the bottom first.
     const order=droppable.sort((a,b)=>{
         if(a===closerIdx && b!==closerIdx) return 1;
         if(b===closerIdx && a!==closerIdx) return -1;
@@ -449,7 +450,7 @@ function computeDroppedSongs(elapsed){
         const pa=da===0?Infinity:da;
         const pb=db===0?Infinity:db;
         if(pa!==pb) return pa-pb;
-        return a-b;
+        return b-a;
     });
 
     for(const idx of order){


### PR DESCRIPTION
## Summary
- restore dropping from the bottom when songs share a drop order
- keep closer at the end of the drop sequence

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684077764384832eb04e1e1e2ee54db1