### PR TITLE
Fix timer remaining calculation

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -485,7 +485,8 @@ function remainingDuration(withDrops, elapsed){
         total += songs[idx].duration;
         if(j < remainIdx.length-1) total += transition;
     });
-    const progress = Math.max(0, elapsed - songStart);
+    const curSongDur = songs[currentIndex] ? songs[currentIndex].duration : 0;
+    const progress = Math.min(curSongDur, Math.max(0, elapsed - songStart));
     return Math.max(0, total - progress);
 }
 


### PR DESCRIPTION
## Summary
- fix remaining duration calculation so it stops counting down after song length is exceeded

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407a5aa57c832ea803582378b9939d