### PR TITLE
Add Spotify song enrichment script

### DIFF
--- a/sor/scripts/spotify_song_enricher.py
+++ b/sor/scripts/spotify_song_enricher.py
@@ -1,0 +1,109 @@
+import os
+import csv
+import argparse
+import requests
+
+SPOTIFY_SEARCH_URL = "https://api.spotify.com/v1/search"
+SPOTIFY_AUDIO_FEATURE_URL = "https://api.spotify.com/v1/audio-features/{id}"
+
+
+def get_api_key() -> str:
+    """Return the Spotify API key from the SPOTIFY_API_KEY environment variable."""
+    api_key = os.getenv("SPOTIFY_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "SPOTIFY_API_KEY environment variable not found."
+        )
+    return api_key
+
+
+def search_track(title: str, artist: str, token: str):
+    """Search for a track on Spotify and return the first result's ID."""
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {
+        "q": f"track:{title} artist:{artist}",
+        "type": "track",
+        "limit": 1,
+    }
+    response = requests.get(SPOTIFY_SEARCH_URL, headers=headers, params=params)
+    response.raise_for_status()
+    data = response.json()
+    items = data.get("tracks", {}).get("items", [])
+    if not items:
+        return None
+    return items[0]["id"]
+
+
+def fetch_audio_features(track_id: str, token: str) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    url = SPOTIFY_AUDIO_FEATURE_URL.format(id=track_id)
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def enrich_row(row: dict, token: str) -> dict:
+    title = row.get("Song") or row.get("Title") or row.get("song") or row.get("title")
+    artist = row.get("Artist") or row.get("artist")
+    if not title or not artist:
+        return row
+    try:
+        track_id = search_track(title, artist, token)
+        if not track_id:
+            row.update({
+                "BPM": "",
+                "Duration": "",
+                "Key": "",
+                "Guitar Tuning": "",
+                "Style": "",
+            })
+            return row
+        features = fetch_audio_features(track_id, token)
+        row.update({
+            "BPM": features.get("tempo"),
+            "Duration": round(features.get("duration_ms", 0) / 1000),
+            "Key": features.get("key"),
+            "Guitar Tuning": "Standard",
+            "Style": "Major" if features.get("mode") == 1 else "Minor",
+        })
+    except Exception as exc:
+        row.update({
+            "BPM": "",
+            "Duration": "",
+            "Key": "",
+            "Guitar Tuning": "",
+            "Style": "",
+        })
+    return row
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Enrich a setlist CSV with Spotify info")
+    parser.add_argument("input_csv", help="Path to input CSV file")
+    parser.add_argument("output_csv", help="Path to output CSV file")
+    args = parser.parse_args()
+
+    api_key = get_api_key()
+
+    with open(args.input_csv, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        fieldnames = reader.fieldnames or []
+
+    extra_fields = ["BPM", "Duration", "Key", "Guitar Tuning", "Style"]
+    for fld in extra_fields:
+        if fld not in fieldnames:
+            fieldnames.append(fld)
+
+    enriched = [enrich_row(row, api_key) for row in rows]
+
+    with open(args.output_csv, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(enriched)
+
+    print(f"Wrote enriched CSV to {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `sor/scripts` directory
- add script `spotify_song_enricher.py` for enriching setlist CSV files with Spotify data
- use `SPOTIFY_API_KEY` environment variable exclusively

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684339544a5c832ebbaebff5d55fad55