### PR TITLE
Auto hide setlist panel

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -167,6 +167,23 @@
       width:4em;
   }
 
+  body.panel-hidden #songsColumn{
+      display:none;
+  }
+  body.panel-hidden #navControls button{
+      font-size:1.8em;
+      padding:20px 30px;
+  }
+  body.panel-hidden #currentSongDisplay{
+      font-size:2.5em;
+  }
+  body.panel-hidden #nextSongDisplay{
+      font-size:1.5em;
+  }
+  body.panel-hidden #timerDisplay{
+      font-size:3.5em;
+  }
+
   #contentWrapper{
       display:flex;
       flex-direction:column;
@@ -209,6 +226,7 @@
     <button id="prevBtn">&lt;</button>
     <button id="nextBtn">&gt;</button>
     <button id="dropBtn">Drop Songs</button>
+    <button id="togglePanelBtn">Hide List</button>
 </div>
 <div id="currentSongDisplay"></div>
 <div id="songNotesDisplay" style="text-align:center;margin-bottom:5px;"></div>
@@ -260,6 +278,28 @@ function goFullscreen() {
         elem.msRequestFullscreen();
     }
 }
+
+const toggleBtn = document.getElementById('togglePanelBtn');
+let panelVisible = true;
+
+function showSongsPanel(){
+    document.body.classList.remove('panel-hidden');
+    panelVisible = true;
+    if(toggleBtn) toggleBtn.textContent = 'Hide List';
+}
+
+function hideSongsPanel(){
+    document.body.classList.add('panel-hidden');
+    panelVisible = false;
+    if(toggleBtn) toggleBtn.textContent = 'Show List';
+}
+
+function toggleSongsPanel(){
+    if(panelVisible) hideSongsPanel();
+    else showSongsPanel();
+}
+
+if(toggleBtn) toggleBtn.addEventListener('click', toggleSongsPanel);
 let songs = [];
 let timer = null;
 let startTime = null;
@@ -698,6 +738,7 @@ function startTimer(){
     startTime=Date.now();
     isPaused=false;
     totalPause=0;
+    hideSongsPanel();
 
     const endInput=document.getElementById('endBy');
     if(endInput && endInput.value){
@@ -784,6 +825,7 @@ function stopTimer(){
     updateButtonStates();
     updateDisplay();
     saveState();
+    showSongsPanel();
 }
 
 document.getElementById('startBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- auto hide the setlist column when the performance starts
- add Hide/Show List button
- expand button and text sizes while the list is hidden

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68443626b25c832ead2ab6e6b35cdfea