### PR TITLE
Move file controls into songs panel

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -356,8 +356,6 @@
 </div> <!-- infoColumn -->
 <div id="songsColumn">
 <ul id="setlist"></ul>
-</div>
-</div> <!-- contentWrapper -->
 <div id="fileControls">
     <div class="file-row">
         <input type="file" id="csvFile" accept=".csv">
@@ -370,6 +368,7 @@
     </div>
 </div>
 </div>
+</div> <!-- contentWrapper -->
 </div>
 <script>
 function goFullscreen() {


### PR DESCRIPTION
## Summary
- move file input and timing fields into the right panel so they hide when the song list panel is toggled

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68450e5b7f9c832e9de9eccc44230383