### PR TITLE
Rearrange timer layout

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -79,15 +79,11 @@
       font-size:1.5em;
       margin:10px 0;
   }
-  #clockTime,#projectedEnd,#metadataLine{
+  #timeLine,#metadataLine{
       text-align:center;
       margin:4px 0;
-      font-size:1em;
+      font-size:1.2em;
       color:#bbb;
-  }
-  #clockTime,#projectedEnd{
-      display:inline-block;
-      margin:4px 8px;
   }
   #setlist { list-style:none; padding:0; }
   #setlist li {
@@ -323,15 +319,14 @@
 <div class="container show-details">
 <div id="contentWrapper">
 <div id="infoColumn">
+  <span id="timerDisplay">00:00</span>
+  <div id="timeLine"></div>
+  <div id="progressContainer"><div id="progressBar"></div></div>
 <div id="currentSongDisplay"></div>
 <div id="songNotesDisplay" style="text-align:center;margin-bottom:5px;"></div>
 <div id="nextSongDisplay"></div>
-  <div id="progressContainer"><div id="progressBar"></div></div>
-  <span id="timerDisplay">00:00</span>
   <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
 <div id="aheadBehind"></div>
-<div id="clockTime"></div>
-<div id="projectedEnd"></div>
 <div id="metadataLine"></div>
 <div id="infoSpacer"></div>
 <button id="infoToggle" title="Show details">ℹ️</button>
@@ -807,15 +802,11 @@ function updateDisplay(){
             diffEl.textContent='';
         }
     }
-    const clockEl=document.getElementById('clockTime');
-    if(clockEl){
-        clockEl.textContent=`Now: ${formatClock(new Date())}`;
-    }
-    const endEl=document.getElementById('projectedEnd');
-    if(endEl){
+    const timeLine=document.getElementById('timeLine');
+    if(timeLine){
         const rd=remainingDuration(true, elapsed);
         const endTime=new Date(Date.now()+rd*1000);
-        endEl.textContent=`Setlist End: ${formatClock(endTime)}`;
+        timeLine.textContent=`Time: ${formatClock(new Date())} -> ${formatClock(endTime)} (Estimated Finish)`;
     }
     const meta=document.getElementById('metadataLine');
     if(meta){

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -36,7 +36,7 @@
       font-weight:300;
   }
   #timerDisplay {
-      font-size:4.5em;
+      font-size:4em;
       font-weight:bold;
       text-align:center;
       display:block;
@@ -45,10 +45,13 @@
       text-shadow:0 0 5px #0cf;
   }
   #currentSongDisplay {
-      font-size:2.5em;
+      font-size:3em;
       font-weight:bold;
       text-align:center;
       margin-bottom:0.3em;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
   }
   #songNotesDisplay {
       text-align:center;
@@ -60,6 +63,9 @@
       text-align:center;
       margin-bottom:20px;
       color:#7abaff;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
   }
   #progressContainer {
       height:20px;
@@ -221,13 +227,13 @@
       max-width:160px;
   }
   body.panel-hidden #currentSongDisplay{
-      font-size:2.5em;
+      font-size:3em;
   }
   body.panel-hidden #nextSongDisplay{
       font-size:1.5em;
   }
   body.panel-hidden #timerDisplay{
-      font-size:4.5em;
+      font-size:4em;
   }
   #metadataLine,
   #metronomeControls{ display:none; }
@@ -309,8 +315,8 @@
           font-size:1.2em;
           padding:12px 20px;
       }
-      #currentSongDisplay{ font-size:1.8em; }
-      #nextSongDisplay{ font-size:1.2em; }
+      #currentSongDisplay{ font-size:1.8em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+      #nextSongDisplay{ font-size:1.2em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   }
 </style>
 </head>
@@ -320,13 +326,13 @@
 <div id="contentWrapper">
 <div id="infoColumn">
   <span id="timerDisplay">00:00</span>
+  <div id="aheadBehind"></div>
   <div id="timeLine"></div>
   <div id="progressContainer"><div id="progressBar"></div></div>
-<div id="currentSongDisplay"></div>
+  <div id="currentSongDisplay"></div>
 <div id="songNotesDisplay" style="text-align:center;margin-bottom:5px;"></div>
 <div id="nextSongDisplay"></div>
   <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
-<div id="aheadBehind"></div>
 <div id="metadataLine"></div>
 <div id="infoSpacer"></div>
 <button id="infoToggle" title="Show details">ℹ️</button>


### PR DESCRIPTION
## Summary
- move main timer to top of info column
- show current/end time together below the timer
- move current song info down where the timer used to be

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845113bba3c832eb4a3dee1c9e3a47e