### PR TITLE
Update Drop Songs button

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -153,14 +153,16 @@
       align-items:center;
       justify-content:center;
   }
-  #dropBtn{ flex-basis:calc(50% - 15px); }
+  /* subtle red tint for drop button */
+  #dropBtn{ background:#332222; }
   #togglePanelBtn{ width:70px; }
   #navControls button:active{
       background:#333;
       transform:scale(0.97);
   }
+  /* less intense highlight for drop button when manual drop needed */
   .highlight{
-      background:#ff9800 !important;
+      background:#883333 !important;
   }
   #metronomeControls{
       text-align:center;
@@ -348,7 +350,7 @@
   <div id="navControls">
       <button id="startBtn" class="icon-btn">▶️</button>
       <button id="stopBtn" class="icon-btn" disabled>⏹️</button>
-      <button id="dropBtn">Drop Songs</button>
+      <button id="dropBtn" class="icon-btn drop-btn" title="Drop Songs">❌🎵</button>
       <button id="togglePanelBtn" class="icon-btn">☰</button>
   </div>
   <button id="edgePrev" class="edge-nav">⏮️</button>


### PR DESCRIPTION
## Summary
- style Drop Songs button with subtle red tint
- tone down highlight color for Drop Songs alert

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845107bdca0832eab94724ad73984d5