### PR TITLE
Hide unneeded timer

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -332,7 +332,7 @@
   <div id="currentSongDisplay"></div>
 <div id="songNotesDisplay" style="text-align:center;margin-bottom:5px;"></div>
 <div id="nextSongDisplay"></div>
-  <div id="timeRemaining" style="text-align:center;margin-bottom:10px;"></div>
+  <div id="timeRemaining" style="text-align:center;margin-bottom:10px;display:none;"></div>
 <div id="metadataLine"></div>
 <div id="infoSpacer"></div>
 <button id="infoToggle" title="Show details">ℹ️</button>


### PR DESCRIPTION
## Summary
- hide set remaining timer display

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_684517418878832ea1cae3e75b6168b7