### PR TITLE
Adjust nav button width

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -284,7 +284,7 @@
       position:absolute;
       top:0;
       bottom:0;
-      width:40%;
+      width:13%;
       display:flex;
       align-items:center;
       justify-content:center;
@@ -301,9 +301,13 @@
   }
   #edgePrev{
       left:0;
+      justify-content:flex-start;
+      padding-left:10px;
   }
   #edgeNext{
       right:0;
+      justify-content:flex-end;
+      padding-right:10px;
   }
   @media (min-width:800px){
       #contentWrapper{ flex-direction:row; align-items:flex-start; }


### PR DESCRIPTION
## Summary
- reduce the `.edge-nav` button width so left/right controls aren't huge
- align arrow icons to the button edges

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684517b6f46c832ea7c30eaa2f9bd9da