### PR TITLE
Fix container spacing and full-height pages

### DIFF
--- a/sor/setlist_manager.html
+++ b/sor/setlist_manager.html
@@ -24,7 +24,7 @@
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             height: 100vh;
-            padding: 20px;
+            padding: 0;
         }
         
         .container {
@@ -34,6 +34,7 @@
             border-radius: 15px;
             box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
+            min-height: 100vh;
         }
         
         .header {

--- a/sor/setlist_optimizer.html
+++ b/sor/setlist_optimizer.html
@@ -24,7 +24,7 @@
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             height: 100vh;
-            padding: 20px;
+            padding: 0;
         }
         
         .container {
@@ -34,6 +34,7 @@
             border-radius: 15px;
             box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
+            min-height: 100vh;
         }
         
         .header {

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -18,17 +18,17 @@
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       background: #111;
       height: 100vh;
-      padding: 20px;
+      padding: 0;
   }
   .container {
       width: 100%;
-      margin: 0 auto;
+      margin: 0;
       background: rgba(0,0,0,0.6);
       color: white;
-      border: 1px solid rgba(255,255,255,0.8);
       box-shadow: none;
-      padding: 20px;
+      padding: 0;
       position:relative;
+      min-height: 100vh;
   }
   h1 {
       text-align:center;


### PR DESCRIPTION
## Summary
- remove padding and white border from tracker page container
- expand tracker container to fill viewport
- remove body padding from optimizer and manager pages
- expand containers in optimizer and manager pages to full height

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68451b38ad48832e8ba0316591f5341b