### PR TITLE
Fix edge navigation overlap

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -282,7 +282,6 @@
   }
   .edge-nav{
       position:absolute;
-      top:0;
       bottom:0;
       width:13%;
       display:flex;


### PR DESCRIPTION
## Summary
- anchor the next/prev edge navigation buttons to the bottom of the page to keep them from overlapping text

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451b5ad088832eb19f7c78344924b6