### PR TITLE
Improve setlist tracker UI

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -251,6 +251,18 @@
       height:100vh;
       flex:0 0 50%;
       max-width:50vw;
+      min-width:300px;
+      position:relative;
+  }
+  #closePanelBtn{
+      position:absolute;
+      top:10px;
+      right:10px;
+      background:none;
+      border:none;
+      color:#fff;
+      font-size:2em;
+      z-index:301;
   }
   #infoColumn{
       position:relative;
@@ -286,8 +298,9 @@
       bottom:0;
       width:40%;
       display:flex;
-      align-items:center;
+      align-items:flex-end;
       justify-content:center;
+      padding-bottom:20px;
       font-size:3em;
       color:rgba(255,255,255,0.7);
       background:transparent;
@@ -313,6 +326,7 @@
       #contentWrapper{ flex-direction:row; align-items:flex-start; }
       #infoColumn{ flex:1; padding-right:20px; }
       #songsColumn{ flex:0 0 50%; max-width:50vw; height:100vh; }
+      #closePanelBtn{ display:none; }
   }
   @media (max-width:799px){
       #contentWrapper{ flex-direction:column; }
@@ -325,6 +339,7 @@
           background:#111;
           z-index:300;
       }
+      #closePanelBtn{ display:block; }
       body.panel-hidden #songsColumn{ display:none; }
   }
   @media (max-width:600px){
@@ -373,7 +388,8 @@
   <button id="edgeNext" class="edge-nav">⏭️</button>
 </div> <!-- infoColumn -->
 <div id="songsColumn">
-<ul id="setlist"></ul>
+  <button id="closePanelBtn" class="icon-btn">✖️</button>
+  <ul id="setlist"></ul>
 <div id="fileControls">
     <div class="file-row">
         <input type="file" id="csvFile" accept=".csv">
@@ -407,6 +423,7 @@ document.addEventListener('fullscreenchange', () => {
 });
 
 const toggleBtn = document.getElementById('togglePanelBtn');
+const closeBtn = document.getElementById('closePanelBtn');
 const edgePrev = document.getElementById('edgePrev');
 const edgeNext = document.getElementById('edgeNext');
 let panelVisible = true;
@@ -431,6 +448,7 @@ function toggleSongsPanel(){
 
 
 if(toggleBtn) toggleBtn.addEventListener('click', toggleSongsPanel);
+if(closeBtn) closeBtn.addEventListener('click', hideSongsPanel);
 let songs = [];
 let timer = null;
 let startTime = null;

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -248,7 +248,7 @@
   }
   #songsColumn{
       overflow-y:auto;
-      max-height:60vh;
+      height:100vh;
       flex:0 0 50%;
       max-width:50vw;
   }
@@ -260,15 +260,13 @@
       flex:1;
       min-height:100vh;
   }
-  #infoSpacer{
-      flex-grow:1;
-  }
   #centerInfo{
       text-align:center;
-      margin:auto 0;
-      padding-top:20px;
+      flex:1;
+      padding:20px 0;
       display:flex;
       flex-direction:column;
+      justify-content:center;
       align-items:center;
   }
   #fullscreenBtn{
@@ -314,7 +312,20 @@
   @media (min-width:800px){
       #contentWrapper{ flex-direction:row; align-items:flex-start; }
       #infoColumn{ flex:1; padding-right:20px; }
-      #songsColumn{ flex:0 0 50%; max-width:50vw; max-height:80vh; }
+      #songsColumn{ flex:0 0 50%; max-width:50vw; height:100vh; }
+  }
+  @media (max-width:799px){
+      #contentWrapper{ flex-direction:column; }
+      #songsColumn{
+          position:fixed;
+          inset:0;
+          width:100vw;
+          height:100vh;
+          max-width:none;
+          background:#111;
+          z-index:300;
+      }
+      body.panel-hidden #songsColumn{ display:none; }
   }
   @media (max-width:600px){
       #navControls button{
@@ -342,7 +353,6 @@
     <div id="timeRemaining" style="text-align:center;margin-bottom:10px;display:none;"></div>
     <div id="metadataLine"></div>
   </div>
-  <div id="infoSpacer"></div>
   <div id="metronomeControls">
       <label><input type="checkbox" id="metronomeToggle"></label>
       <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -258,6 +258,7 @@
       flex-direction:column;
       align-items:center;
       flex:1;
+      min-height:100vh;
   }
   #infoSpacer{
       flex-grow:1;
@@ -265,6 +266,7 @@
   #centerInfo{
       text-align:center;
       margin:auto 0;
+      padding-top:20px;
       display:flex;
       flex-direction:column;
       align-items:center;

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -52,11 +52,16 @@
       white-space:nowrap;
       overflow:hidden;
       text-overflow:ellipsis;
+      max-width:100%;
   }
   #songNotesDisplay {
       text-align:center;
       font-size:1.1em;
       margin-bottom:5px;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
+      max-width:100%;
   }
   #nextSongDisplay {
       font-size:1.6em;
@@ -66,6 +71,7 @@
       white-space:nowrap;
       overflow:hidden;
       text-overflow:ellipsis;
+      max-width:100%;
   }
   #progressContainer {
       height:20px;
@@ -257,7 +263,7 @@
   #closePanelBtn{
       position:absolute;
       top:10px;
-      right:10px;
+      left:10px;
       background:none;
       border:none;
       color:#fff;

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -132,7 +132,7 @@
       justify-content:center;
       flex-wrap:wrap;
       gap:15px;
-      margin-top:15px;
+      margin-top:auto;
       margin-bottom:15px;
       position:relative;
       z-index:200;
@@ -238,10 +238,6 @@
   body.panel-hidden #timerDisplay{
       font-size:4em;
   }
-  #metadataLine,
-  #metronomeControls{ display:none; }
-  .show-details #metadataLine,
-  .show-details #metronomeControls{ display:block; }
   body.panel-hidden #metadataLine{ display:none; }
 
   #contentWrapper{
@@ -259,20 +255,10 @@
       position:relative;
       display:flex;
       flex-direction:column;
+      align-items:center;
   }
   #infoSpacer{
       flex-grow:1;
-  }
-  #infoToggle{
-      position:absolute;
-      bottom:15px;
-      right:15px;
-      background:none;
-      border:none;
-      color:#bbb;
-      font-size:1.6em;
-      cursor:pointer;
-      z-index:200;
   }
   #fullscreenBtn{
       position:fixed;
@@ -287,6 +273,7 @@
   }
   .edge-nav{
       position:absolute;
+      top:0;
       bottom:0;
       width:13%;
       display:flex;
@@ -330,7 +317,7 @@
 </head>
 <body>
 <button id="fullscreenBtn" onclick="goFullscreen()">⛶</button>
-<div class="container show-details">
+<div class="container">
 <div id="contentWrapper">
 <div id="infoColumn">
   <span id="timerDisplay">00:00</span>
@@ -343,7 +330,6 @@
   <div id="timeRemaining" style="text-align:center;margin-bottom:10px;display:none;"></div>
 <div id="metadataLine"></div>
 <div id="infoSpacer"></div>
-<button id="infoToggle" title="Show details">ℹ️</button>
   <div id="metronomeControls">
       <label><input type="checkbox" id="metronomeToggle"></label>
       <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>
@@ -398,7 +384,6 @@ document.addEventListener('fullscreenchange', () => {
 });
 
 const toggleBtn = document.getElementById('togglePanelBtn');
-const infoBtn = document.getElementById('infoToggle');
 const edgePrev = document.getElementById('edgePrev');
 const edgeNext = document.getElementById('edgeNext');
 let panelVisible = true;
@@ -420,11 +405,7 @@ function toggleSongsPanel(){
     else showSongsPanel();
 }
 
-function toggleDetails(){
-    document.querySelector('.container').classList.toggle('show-details');
-}
 
-if(infoBtn) infoBtn.addEventListener('click', toggleDetails);
 
 if(toggleBtn) toggleBtn.addEventListener('click', toggleSongsPanel);
 let songs = [];
@@ -951,7 +932,9 @@ document.getElementById('startBtn').addEventListener('click', () => {
     if(!startTime) startTimer();
     else togglePause();
 });
-document.getElementById('stopBtn').addEventListener('click', stopTimer);
+document.getElementById('stopBtn').addEventListener('click', () => {
+    if(confirm('Are you sure you want to stop?')) stopTimer();
+});
 function goPrev(){
     currentIndex = Math.max(0, currentIndex - 1);
     const elapsed = startTime ? Math.floor(getElapsedMs() / 1000) : 0;

--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -244,6 +244,7 @@
       display:flex;
       flex-direction:column;
       gap:20px;
+      min-height:100vh;
   }
   #songsColumn{
       overflow-y:auto;
@@ -256,9 +257,17 @@
       display:flex;
       flex-direction:column;
       align-items:center;
+      flex:1;
   }
   #infoSpacer{
       flex-grow:1;
+  }
+  #centerInfo{
+      text-align:center;
+      margin:auto 0;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
   }
   #fullscreenBtn{
       position:fixed;
@@ -275,7 +284,7 @@
       position:absolute;
       top:0;
       bottom:0;
-      width:13%;
+      width:40%;
       display:flex;
       align-items:center;
       justify-content:center;
@@ -324,12 +333,14 @@
   <div id="aheadBehind"></div>
   <div id="timeLine"></div>
   <div id="progressContainer"><div id="progressBar"></div></div>
-  <div id="currentSongDisplay"></div>
-<div id="songNotesDisplay" style="text-align:center;margin-bottom:5px;"></div>
-<div id="nextSongDisplay"></div>
-  <div id="timeRemaining" style="text-align:center;margin-bottom:10px;display:none;"></div>
-<div id="metadataLine"></div>
-<div id="infoSpacer"></div>
+  <div id="centerInfo">
+    <div id="currentSongDisplay"></div>
+    <div id="songNotesDisplay" style="text-align:center;margin-bottom:5px;"></div>
+    <div id="nextSongDisplay"></div>
+    <div id="timeRemaining" style="text-align:center;margin-bottom:10px;display:none;"></div>
+    <div id="metadataLine"></div>
+  </div>
+  <div id="infoSpacer"></div>
   <div id="metronomeControls">
       <label><input type="checkbox" id="metronomeToggle"></label>
       <label>BPM: <input type="number" id="bpmInput" value="120" min="30" style="width:5em"></label>


### PR DESCRIPTION
## Summary
- remove info toggle and always show details
- center primary info
- stretch next/previous track buttons
- confirm before stopping the timer

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684520be9e4c832e9de4d45489f2c436