### PR TITLE
Skip disabled songs on Next click

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -790,7 +790,9 @@ function updateDisplay(){
     }
     const nextEl=document.getElementById('nextSongDisplay');
     if(nextEl){
-        const nextSong=songs[currentIndex+1];
+        let idx=currentIndex+1;
+        while(idx<songs.length && songs[idx].dropped) idx++;
+        const nextSong=idx<songs.length?songs[idx]:null;
         nextEl.textContent=nextSong?`Next Up: ${nextSong.title} - ${nextSong.artist}`:'';
     }
     const diffEl=document.getElementById('aheadBehind');
@@ -969,10 +971,14 @@ function goNext(){
             const trans = elapsed - actualStart[currentIndex] - songs[currentIndex].duration;
             if (trans >= 0) transitionDurations[currentIndex] = trans;
         }
-        currentIndex = Math.min(songs.length - 1, currentIndex + 1);
-        songStart = elapsed;
-        startDiff[currentIndex] = elapsed - songs[currentIndex].start;
-        actualStart[currentIndex] = elapsed;
+        let nextIndex = currentIndex + 1;
+        while(nextIndex < songs.length && songs[nextIndex].dropped) nextIndex++;
+        if(nextIndex < songs.length){
+            currentIndex = nextIndex;
+            songStart = elapsed;
+            startDiff[currentIndex] = elapsed - songs[currentIndex].start;
+            actualStart[currentIndex] = elapsed;
+        }
     }
     updateDisplay();
     saveState();


### PR DESCRIPTION
## Summary
- update `updateDisplay` to show the next non-dropped song
- modify `goNext` to skip songs marked as dropped

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684521c49fcc832e95e7be63c265e9e2