### PR TITLE
Add offline caching for setlist tracker

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -1054,6 +1054,11 @@ document.getElementById('bpmInput').addEventListener('change', e=>{
 });
 loadState();
 updateDropBtn(0);
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+    });
+}
 </script>
 </body>
 </html>

--- a/sor/sw.js
+++ b/sor/sw.js
@@ -1,0 +1,26 @@
+const CACHE_NAME = 'setlist-tracker-v1';
+const URLS_TO_CACHE = [
+  './setlist_tracker.html',
+  './sw.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- register a service worker in `setlist_tracker.html`
- add `sw.js` with caching logic for offline support

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f9afb2ec832e92a8dfa535e84c84