### PR TITLE
Fix tracker panel height on mobile

### DIFF
--- a/sor/setlist_tracker.html
+++ b/sor/setlist_tracker.html
@@ -6,18 +6,25 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
+<script>
+function updateVh() {
+    document.documentElement.style.setProperty('--vh', window.innerHeight * 0.01 + 'px');
+}
+window.addEventListener('resize', updateVh);
+updateVh();
+</script>
  <style>
   html, body {
       margin: 0;
       padding: 0;
       overflow: hidden;
-      height: 100vh;
+      height: calc(var(--vh, 1vh) * 100);
   }
 
   body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       background: #111;
-      height: 100vh;
+      height: calc(var(--vh, 1vh) * 100);
       padding: 0;
   }
   .container {
@@ -28,7 +35,7 @@
       box-shadow: none;
       padding: 0;
       position:relative;
-      min-height: 100vh;
+      min-height: calc(var(--vh, 1vh) * 100);
   }
   h1 {
       text-align:center;
@@ -250,11 +257,11 @@
       display:flex;
       flex-direction:column;
       gap:20px;
-      min-height:100vh;
+      min-height: calc(var(--vh, 1vh) * 100);
   }
   #songsColumn{
       overflow-y:auto;
-      height:100vh;
+      height: calc(var(--vh, 1vh) * 100);
       flex:0 0 50%;
       max-width:50vw;
       min-width:300px;
@@ -276,7 +283,7 @@
       flex-direction:column;
       align-items:center;
       flex:1;
-      min-height:100vh;
+      min-height: calc(var(--vh, 1vh) * 100);
   }
   #centerInfo{
       text-align:center;
@@ -331,7 +338,7 @@
   @media (min-width:800px){
       #contentWrapper{ flex-direction:row; align-items:flex-start; }
       #infoColumn{ flex:1; padding-right:20px; }
-      #songsColumn{ flex:0 0 50%; max-width:50vw; height:100vh; }
+      #songsColumn{ flex:0 0 50%; max-width:50vw; height: calc(var(--vh, 1vh) * 100); }
       #closePanelBtn{ display:none; }
   }
   @media (max-width:799px){
@@ -340,7 +347,7 @@
           position:fixed;
           inset:0;
           width:100vw;
-          height:100vh;
+          height: calc(var(--vh, 1vh) * 100);
           max-width:none;
           background:#111;
           z-index:300;


### PR DESCRIPTION
## Summary
- make setlist tracker use dynamic viewport height units
- add JS to maintain `--vh` custom property

## Testing
- `bundle exec jekyll build` *(fails: bundler could not install)*

------
https://chatgpt.com/codex/tasks/task_e_684706661034832ea143f5cf5cbd62e3